### PR TITLE
Corrections for when blocking Read() is called when fields are missing.

### DIFF
--- a/XBee.Core/SerialDeviceStream.cs
+++ b/XBee.Core/SerialDeviceStream.cs
@@ -53,18 +53,7 @@ namespace XBee
 
             byte[] data = dataTask.Result;
 
-            if (data.Length == count)
-            {
-                for (int i = 0; i < data.Length; i++)
-                {
-                    buffer[i] = data[i];
-                }
-            }
-            else
-            {
-                throw new InvalidOperationException();
-            }
-
+            Array.Copy(data, buffer, data.Length);
             return data.Length;
         }
 


### PR DESCRIPTION
Test fix relating to #62.